### PR TITLE
Support for automatic reimporting

### DIFF
--- a/Assets/Plugins/MetaSprite/Editor/ImportSettings.cs
+++ b/Assets/Plugins/MetaSprite/Editor/ImportSettings.cs
@@ -46,6 +46,7 @@ public class ImportSettings : ScriptableObject {
         }
     }
 
+    public bool automaticReimport;
 }
 
 [CustomEditor(typeof(ImportSettings))]
@@ -71,8 +72,9 @@ public class ImportSettingsEditor : Editor {
 
         settings.densePacked = EGL.Toggle("Dense Pack", settings.densePacked);
         settings.border = EGL.IntField("Border", settings.border);
+        settings.automaticReimport = EGL.Toggle("Automatic Reimport", settings.automaticReimport);
 
-        EGL.Space();
+            EGL.Space();
         using (new GL.HorizontalScope(EditorStyles.toolbar)) {
             GL.Label("Output");
         }

--- a/Assets/Plugins/MetaSprite/Editor/ImportSettingsReference.cs
+++ b/Assets/Plugins/MetaSprite/Editor/ImportSettingsReference.cs
@@ -1,13 +1,51 @@
-﻿using System.Collections;
+﻿using System.IO;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEditor;
 
 namespace MetaSprite {
 
 public class ImportSettingsReference : ScriptableObject {
 
     public ImportSettings settings;
-    
-}
+
+    public static string GetImportSettingsPath(DefaultAsset asset)
+    {
+        var guid = AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(asset));
+        var path = pluginPath + "/FileSettings/" + guid + ".asset";
+        return path;
+    }
+
+    public static ImportSettingsReference LoadImportSettings(DefaultAsset asset)
+    {
+        var settingsPath = GetImportSettingsPath(asset);
+        return (ImportSettingsReference)AssetDatabase.LoadAssetAtPath(settingsPath, typeof(ImportSettingsReference));
+    }
+
+    static string pluginPath_;
+
+    static string pluginPath
+    {
+        get
+        {
+            if (pluginPath_ != null)
+            {
+                return pluginPath_;
+            }
+
+            var testInstance = ScriptableObject.CreateInstance<ProjectTestInstance>();
+            var script = MonoScript.FromScriptableObject(testInstance);
+            var scriptPath = AssetDatabase.GetAssetPath(script);
+
+            ScriptableObject.DestroyImmediate(testInstance, true);
+
+            pluginPath_ = Path.GetDirectoryName(Path.GetDirectoryName(Path.GetDirectoryName(scriptPath)));
+
+            return pluginPath_;
+        }
+    }
+
+    }
 
 }

--- a/Assets/Plugins/MetaSprite/Editor/MetaLayerAssetPostProcessor.cs
+++ b/Assets/Plugins/MetaSprite/Editor/MetaLayerAssetPostProcessor.cs
@@ -1,0 +1,52 @@
+﻿using UnityEngine;
+using System;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using Random = UnityEngine.Random;
+using UnityEditor;
+
+namespace MetaSprite
+{
+	public class MetaLayerAssetPostprocessor : AssetPostprocessor
+    {
+        private static List<string> _autoImports = new List<string>();
+        private static EditorApplication.CallbackFunction _importDelegate = new EditorApplication.CallbackFunction(CompleteAutoImports);
+
+        private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromPath)
+		{
+            string[] aseAssetPaths = importedAssets
+                .Where(path => IsAsepriteFile(path))
+                .ToArray();
+            if (aseAssetPaths.Length > 0)
+            {
+                _autoImports.Clear();
+                _autoImports.AddRange(aseAssetPaths);
+                // Post-pone actual import for one frame to prevent errors due to atlas texture creation
+                EditorApplication.update = Delegate.Combine(EditorApplication.update, _importDelegate) as EditorApplication.CallbackFunction;
+            }
+        }
+
+        public static bool IsAsepriteFile(string path)
+        {
+            return path.EndsWith(".ase") || path.EndsWith(".aseprite");
+        }
+
+        private static void CompleteAutoImports()
+        {
+            EditorApplication.update = Delegate.Remove(EditorApplication.update, _importDelegate as EditorApplication.CallbackFunction) as EditorApplication.CallbackFunction;
+            AssetDatabase.Refresh();
+            ASEImporter.Refresh();
+            foreach (var path in _autoImports)
+            {
+                var asset = AssetDatabase.LoadAssetAtPath<DefaultAsset>(path);
+                var reference = ImportSettingsReference.LoadImportSettings(asset);
+                if (reference?.settings && reference.settings.automaticReimport)
+                {
+                    ASEImporter.Import(asset, reference.settings);
+                }
+            }
+            _autoImports.Clear();
+        }
+    }
+}

--- a/Assets/Plugins/MetaSprite/Editor/MetaLayerAssetPostProcessor.cs.meta
+++ b/Assets/Plugins/MetaSprite/Editor/MetaLayerAssetPostProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eea32ab9543056c43866d8bb81861a53
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull request add support for automatic reimporting of .aseprite and .ase assets whenever the editor regains focus. "Automatic Reimport" must be enabled in the ImportSettings object for this feature to work on a particular file.

I've made the following source changes:

- Added AnimationAssetPostprocessor which is an implementation of Unity's [AssetPostprocessor](https://docs.unity3d.com/ScriptReference/AssetPostprocessor.html) in order to detect asset changes and call AseImporter.Import() as appropriate.
- Refactored a few of the private static functions previously found in ImportMenu.cs into public functions found in ImportSettingsReference.cs for easier access (felt this was the most appropriate location).
- Added an "automaticReimport" boolean to the ImportSettings object. Currently this is defaulted to false. This must be set to true in order for assets referencing this ImportSettings to be reimported.

This hasn't been super thoroughly tested yet. However, much of this is based on how [Animation Importer](https://github.com/talecrafter/AnimationImporter) does the same, so I don't anticipate major problems.

I'll be happy to make any changes you want. Thanks!